### PR TITLE
change readme to show usage of npm install pbf-loader, change example…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Webpack loader for .proto files
 - uses [protocol-buffers-schema](https://github.com/mafintosh/protocol-buffers-schema) as schema parser
 - returns a compiled module ready to be used when you `require('./file.proto')`
 
+Installation
+------------
+```sh
+npm install pbf-loader
+```
+
 Usage
 ------
 
@@ -13,14 +19,12 @@ see [example](./example/) for sample implementation.
 
 Given your ```webpack.config.js``` like this:
 ```javascript
-const pbfLoader = path.resolve(__dirname, "../src/index.js");
-
 module.exports = {
     module: {
         loaders: [
             {
                 test: /\.proto$/,
-                loader: pbfLoader
+                loader: "pbf-loader"
             }
         ]
     }
@@ -56,14 +60,12 @@ const buffer = pbf.finish();
 ```
 You can refer to [index.proto](./example/index.proto) for how the .proto file looks like.
 
-
 Test
 ----
 Assuming you already did `npm install`, you can:
-```bash
+```sh
 npm test
 ```
-
 
 ## License
 This project is released under the terms of the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0).

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var path = require("path");
-var protoLoader = path.resolve(__dirname, "../src/index.js");
 
 module.exports = {
     entry: path.resolve(__dirname, "./index.js"),
@@ -13,7 +12,7 @@ module.exports = {
         loaders: [
             {
                 test: /\.proto$/,
-                loader: protoLoader
+                loader: "pbf-loader"
             }
         ]
     }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   },
   "author": "Bishesh Tiwaree <bishesh.tiwaree@trivago.com>",
   "license": "Apache 2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trivago/pbf-loader"
+  },
   "dependencies": {
     "pbf": "^3.0.5",
     "protocol-buffers-schema": "^3.1.1",


### PR DESCRIPTION
- add `npm install pbf-loader` in README
- add usage of pbf-loader in webpack.config.js in README
- change example implementation under /example

fixes https://github.com/trivago/pbf-loader/issues/1